### PR TITLE
webpack: Fix CSS Modules

### DIFF
--- a/src/theme/AppTheme.tsx
+++ b/src/theme/AppTheme.tsx
@@ -5,6 +5,7 @@ import { fas } from '@fortawesome/free-solid-svg-icons';
 import ThemeProvider from '@mui/system/ThemeProvider';
 
 import { theme } from './theme';
+import './styles.css';
 
 
 type Props = {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,6 +13,20 @@ export default {
             },
             {
                 test: /\.css$/,
+                exclude: [/node_modules/],
+                use: [
+                    'style-loader',
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: true,
+                        },
+                    },
+                ],
+            },
+            {
+                test: /\.css$/,
+                include: [/node_modules/],
                 use: [
                     'style-loader',
                     {


### PR DESCRIPTION
I go back and forth between CSS modules making me more productive or less productive :D. This commit splits the CSS imports so that our CSS imports are modules but CSS imported from a node module can be imported generically. This is to support components like SwaggerUI that require a lot of CSS and don't make it super easy to use the module.