### PR TITLE
bugfix: Fix logo on Safari.

### DIFF
--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -52,8 +52,8 @@ export default function Header({ open, handleOpen }: Props) {
                 </IconButton>
                 <Box sx={{ flexGrow: 1 }} />
                 <Link to="/">
-                    <Box sx={{ display: { xs: 'flex', md: 'flex' }, height: "16px" }}>
-                        <Logo color={solarized.base1} />
+                    <Box sx={{ display: { xs: 'flex', md: 'flex' }, height: '16px' }}>
+                        <Logo color={solarized.base1} height='16px' />
                     </Box>
                 </Link>
                 <Box sx={{ flexGrow: 1 }} />


### PR DESCRIPTION
The Tidbyt logo was not displaying on Safari or iOS browsers. It turns out, the height/width prop is required to render properly on Safari where Chrome is happy to expand the SVG to the div it's in.