### PR TITLE
core: Updates to padding, surfaces, and lists

### DIFF
--- a/src/markdown/CodeBlock.tsx
+++ b/src/markdown/CodeBlock.tsx
@@ -39,7 +39,7 @@ export default function CodeBlock({ inline, className, children }: Props) {
     return (
         <Box sx={{ minWidth: '100%' }}>
             <Paper sx={{ borderRadius: 2, backgroundColor: solarized.base03 }}>
-                <Typography mt={0} mb={4} variant="body2">
+                <Typography mt={4} mb={0} variant="body2">
                     <SyntaxHighlighter
                         customStyle={{
                             background: 'none',

--- a/src/markdown/Heading.tsx
+++ b/src/markdown/Heading.tsx
@@ -23,9 +23,9 @@ export default function Heading({ level, children }: Props) {
     function calcMarginBottom(level: number): number {
         switch (level) {
             case 1:
-                return 2;
-            default:
                 return 0;
+            default:
+                return -4;
         }
     }
 

--- a/src/markdown/Image.tsx
+++ b/src/markdown/Image.tsx
@@ -17,7 +17,7 @@ export default function Image({ src, alt, title, children }: Props) {
                     <Paper
                         sx={{
                             borderRadius: 2,
-                            marginBottom: 4,
+                            marginTop: 4,
                             maxWidth: '100%',
                             height: 'auto',
                         }}

--- a/src/markdown/Paragraph.tsx
+++ b/src/markdown/Paragraph.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export default function Paragraph({ children }: Props) {
     return (
-        <Typography mt={0} mb={4} variant="body2">
+        <Typography mt={4} mb={0} variant="body2">
             {children}
         </Typography>
     );

--- a/src/markdown/list/Item.tsx
+++ b/src/markdown/list/Item.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ListItem, Typography } from '@mui/material';
+import CircleIcon from '@mui/icons-material/Circle';
 
 type Props = {
     index: number,
@@ -9,15 +10,21 @@ type Props = {
 }
 
 export default function Item({ index, ordered, children }: Props) {
-    let prefix = "• ";
     if (ordered) {
-        prefix = `${index + 1}.) `;
+        return (
+            <ListItem key={index}>
+                <Typography component="span" variant="body2">
+                    <strong style={{ paddingRight: 10 }}>{`${index + 1}.`}</strong>{children}
+                </Typography>
+            </ListItem>
+        );
     }
 
     return (
         <ListItem key={index}>
             <Typography component="span" variant="body2">
-                {prefix}{children}
+                <CircleIcon sx={{ fontSize: 10, color: '#000', paddingRight: 1 }} />
+                {children}
             </Typography>
         </ListItem>
     );

--- a/src/markdown/list/ListWrapper.tsx
+++ b/src/markdown/list/ListWrapper.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export default function ListWrapper({ children }: Props) {
     return (
-        <List dense={true} sx={{ marginBottom: 4 }}>
+        <List dense={true}>
             {children}
         </List>
     );

--- a/src/markdown/table/Table.tsx
+++ b/src/markdown/table/Table.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export default function Table({ children }: Props) {
     return (
-        <TableContainer sx={{ marginTop: 2, }} component={Paper}>
+        <TableContainer sx={{ marginTop: 4 }} component={Paper}>
             <MuiTable>
                 {children}
             </MuiTable>


### PR DESCRIPTION
- [core: Convert image to Paper surface.](https://github.com/tidbyt/tidbyt.dev/commit/cf447fb6f4dba6660992f009d4bbc25e326cd0a9) 
    - This commit updates images to use a Paper surface instead of the plain div to make them pop a bit more.
- [core: Update inline codeblock padding.](https://github.com/tidbyt/tidbyt.dev/commit/24b62b00e925f6f72a2f4b1d674c0dc0edf221da) 
    - This commit updates the padding on either side of the inline code block to make it clear that it's something different.
- [bugfix: List padding.](https://github.com/tidbyt/tidbyt.dev/commit/127eab61ac4d05e884548be14195a5f4d8525933) 
    - This commit fixes an issue where there was a lot of space between the proceeding paragraph and the start of the referenced list. To do so, I swapped out the paradigm of "margin bottom" to use a "margin top" structure so that images, code blocks, etc would put the margin at the top and expect the proceeding element to put the margin on top as well. To fix headings, I substracted the margin so there wasn't a large gap between a heading and the first bit of content.