### PR TITLE
github: Add build steps.

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,29 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.1.3-beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.TIDBYT_GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.TIDBYT_GITHUB_TOKEN }}
+        with:
+          path-to-document: https://github.com/tidbyt/tidbyt.dev/blob/main/docs/CLA.md
+          allowlist: tidbyt-bot,renovate-bot,renovate[bot]
+
+          remote-organization-name: tidbyt
+          remote-repository-name: cla-signatures
+          branch: main
+          path-to-signatures: signatures.json
+
+          signed-commit-message: "$contributorName has signed the CLA in tidbyt/tidbyt.dev#$pullRequestNo"
+          lock-pullrequest-aftermerge: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Build Main
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - run: npm run build --if-present

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,18 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - run: npm run build --if-present


### PR DESCRIPTION
This commit adds build steps. Technically, Netlify is responsible for this at the moment. But it's not clear if everyone will be able to get a Netlify build from our community, so I want to add these to ensure we can block on failed builds regardless of if Netlify will provide a link or not.