### PR TITLE
Fix Windows build link

### DIFF
--- a/docs/02_build/02_installing_pixlet.md
+++ b/docs/02_build/02_installing_pixlet.md
@@ -56,7 +56,7 @@ Building Pixlet (on Windows)
 [MINGW64 environment]: https://www.msys2.org/docs/environments/
 
 ## Build from source
-Note - if you're trying to build for windows, check out the [windows build instructions](BUILD_WINDOWS.md).
+Note - if you're trying to build for windows, check out the [windows build instructions](#install-on-windows).
 
 ### Prerequisites
 


### PR DESCRIPTION
Another option for resolving this 404 would be to just remove the sentence. It looks like this content was copied from https://github.com/tidbyt/pixlet/blob/main/docs/BUILD_WINDOWS.md at some point.