### PR TITLE
Remove link to broken image

### DIFF
--- a/docs/06_reference/widgets.md
+++ b/docs/06_reference/widgets.md
@@ -388,7 +388,6 @@ render.Sequence(
   ],
 ),
 ```
-![](img/widget_Sequence_0.gif)
 
 
 ## Stack


### PR DESCRIPTION
The [Sequence code example](https://tidbyt.dev/docs/reference/widgets#sequence) is just a mock example so there’s no corresponding image to show the effect. Seems like it would be best to remove the broken image link.