### PR TITLE
bugfix: Ensure tsc errors cause build failures.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "mui-markdown": "0.5.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-markdown": "^8.0.3",
+        "react-markdown": "8.0.3",
         "react-redux": "8.0.4",
         "react-router": "6.4.2",
         "react-router-dom": "6.4.2",
@@ -70,7 +70,6 @@
         "ts-jest": "29.0.3",
         "ts-loader": "9.4.1",
         "ts-node": "10.9.1",
-        "typed-react-markdown": "^0.1.0",
         "typescript": "4.8.4",
         "url-loader": "4.1.1",
         "webpack": "5.74.0",
@@ -14359,21 +14358,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typed-react-markdown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/typed-react-markdown/-/typed-react-markdown-0.1.0.tgz",
-      "integrity": "sha512-wadBoAeDir62Dc7g0hmdkOrOCIbpSUVqTclXlzm9cOeVSKYKXmS1Jwh7bem+eKJikD/emGxh2Ufxx7a+1mZW+w==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "^0.14.44"
-      }
-    },
-    "node_modules/typed-react-markdown/node_modules/@types/react": {
-      "version": "0.14.57",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-0.14.57.tgz",
-      "integrity": "sha512-NBWpx7QYHlOmfTDUihI9XSaE1cUTk9kDIhB0k/wi5/vHqqMabj3+L7jBAkwjL+APl99LWeatMwAAcDR6B677mw==",
-      "dev": true
-    },
     "node_modules/typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
@@ -26085,23 +26069,6 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
-      }
-    },
-    "typed-react-markdown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/typed-react-markdown/-/typed-react-markdown-0.1.0.tgz",
-      "integrity": "sha512-wadBoAeDir62Dc7g0hmdkOrOCIbpSUVqTclXlzm9cOeVSKYKXmS1Jwh7bem+eKJikD/emGxh2Ufxx7a+1mZW+w==",
-      "dev": true,
-      "requires": {
-        "@types/react": "^0.14.44"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "0.14.57",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-0.14.57.tgz",
-          "integrity": "sha512-NBWpx7QYHlOmfTDUihI9XSaE1cUTk9kDIhB0k/wi5/vHqqMabj3+L7jBAkwjL+APl99LWeatMwAAcDR6B677mw==",
-          "dev": true
-        }
       }
     },
     "typescript": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,10 +5,17 @@ export default {
     module: {
         rules: [
             {
-                test: /\.(js|jsx|ts|tsx)$/,
+                test: /\.(js|js)$/,
                 exclude: /node_modules/,
                 use: {
                     loader: 'babel-loader'
+                }
+            },
+            {
+                test: /\.(ts|tsx)$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'ts-loader'
                 }
             },
             {


### PR DESCRIPTION
This was a silly bug. I couldn't figure out why tsc failures were not causing build failures. It turns out, I was not using ts-loader to load typescript files :facepalm: