### PR TITLE
bugfix: Fix mailto links.

### DIFF
--- a/src/markdown/Link.tsx
+++ b/src/markdown/Link.tsx
@@ -11,7 +11,7 @@ type Props = LinkBaseProps & {
 }
 
 export default function Link({ href, children, ...props }: Props) {
-    if (href.startsWith('http') || href.startsWith('#')) {
+    if (href.startsWith('http') || href.startsWith('#') || href.startsWith('mailto')) {
         return (
             <MuiLink href={href} {...props}>
                 {children}

--- a/src/markdown/Markdown.tsx
+++ b/src/markdown/Markdown.tsx
@@ -46,7 +46,7 @@ export default function Markdown({ source }: Props) {
         <ReactMarkdown
             children={source}
             transformLinkUri={(href: string) => {
-                if (href.startsWith('http') || href.startsWith('#')) {
+                if (href.startsWith('http') || href.startsWith('#') || href.startsWith('mailto')) {
                     return href;
                 }
 


### PR DESCRIPTION
This commit fixes a bug where mailto links would not work as expected and instead try to route to a page on our site. Closes #96.