### PR TITLE
Update docs for new modules and widget properties

### DIFF
--- a/docs/06_reference/modules.md
+++ b/docs/06_reference/modules.md
@@ -28,7 +28,9 @@ individual modules, please refer to the Starlib documentation.
 
 | Module | Description |
 | --- | --- |
+| [`bsoup.star`](https://github.com/qri-io/starlib/blob/master/bsoup) | Beautiful Soup-like functions for HTML |
 | [`compress/gzip.star`](https://github.com/qri-io/starlib/blob/master/compress/gzip) | gzip decompressing |
+| [`compress/zipfile.star`](https://github.com/qri-io/starlib/blob/master/zipfile) | zip decompressing |
 | [`encoding/base64.star`](https://github.com/qri-io/starlib/tree/master/encoding/base64) | Base 64 encoding and decoding |
 | [`encoding/csv.star`](https://github.com/qri-io/starlib/tree/master/encoding/csv) | CSV decoding |
 | [`encoding/json.star`](https://github.com/qri-io/starlib/tree/master/encoding/json) | JSON encoding and decoding |

--- a/docs/06_reference/widgets.md
+++ b/docs/06_reference/widgets.md
@@ -12,6 +12,11 @@ A quick note about colors.  When specifying colors, use a CSS-like
 hexdecimal color specification.  Pixlet supports `#rgb`, `#rrggbb`,
 `#rgba`, and `#rrggbbaa` color specifications.
 
+For animated widgets like Marquee, you can also call `frame_count()`
+to work out how many frames are required to display the whole
+animation. You can also call `size()` on dynamically-sized widgets
+like Text to get the width and height.
+
 ## Animation
 Animations turns a list of children into an animation, where each
 child is a frame.


### PR DESCRIPTION
Realised I had a few PRs on that updated docs on the main repo, but not here where more people will see them:
- https://github.com/tidbyt/pixlet/pull/826
- https://github.com/tidbyt/pixlet/pull/827
- https://github.com/tidbyt/pixlet/pull/853